### PR TITLE
docker-tests: hide mkdir errors if /run dir exists

### DIFF
--- a/docker-tests/start.sh
+++ b/docker-tests/start.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
-mkdir /run || true
-mkdir /run/vpp || true
+mkdir -p /run
+mkdir -p /run/vpp
 /usr/bin/vpp unix { cli-listen /run/vpp/cli.sock } plugins { plugin dpdk_plugin.so { disable } } 2> /dev/null
 
 echo Waiting 10 sec for VPP to boot...


### PR DESCRIPTION
docker-tests: hide mkdir errors if /run dir exists

Signed-off-by: Dave Wallace <dwallacelf@gmail.com>